### PR TITLE
fix: synchronise resource loading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,8 +64,8 @@ const PineconeRouterMiddleware = {
 		let views: any[] = !route
 			? window.PineconeRouter.notfound.view
 			: route.view
-				? route.view
-				: ''
+		        ? route.view
+			: ''
 		if (!views) {
 			window.dispatchEvent(window.PineconeRouter.loadEnd)
 			return
@@ -81,8 +81,8 @@ const PineconeRouterMiddleware = {
 			}
 
 			const response = await fetch(viewPath);
-			const contet = await response.text();
-			return { selector: view.selector, content: contet }
+			const content = await response.text();
+			return { selector: view.selector, content: content }
 
 		})).then(responses => {
 			responses.forEach(response => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,13 +64,13 @@ const PineconeRouterMiddleware = {
 		let views: any[] = !route
 			? window.PineconeRouter.notfound.view
 			: route.view
-			? route.view
-			: ''
+				? route.view
+				: ''
 		if (!views) {
 			window.dispatchEvent(window.PineconeRouter.loadEnd)
 			return
 		}
-		views.forEach(async (view) => {
+		Promise.all(views.map(async view => {
 			let viewPath = ''
 			if (typeof view == 'string') {
 				viewPath = view
@@ -80,30 +80,33 @@ const PineconeRouterMiddleware = {
 				return
 			}
 
-			await fetch(viewPath)
-				.then((response) => {
-					return response.text()
-				})
-				.then((response) => {
-					if (view.selector) {
-						renderContent(response, view.selector)
-					} else {
-						renderContent(response)
-					}
-					window.dispatchEvent(window.PineconeRouter.loadEnd)
-				})
-				.catch((error) => {
-					const el = document.querySelector(
-						window.PineconeRouter.settings.viewSelector ?? '#app'
-					)
-					if (el) {
-						el.dispatchEvent(
-							new CustomEvent('fetch-error', { detail: error })
-						)
-					}
-					console.error(`Pinecone Router: Fetch Error: ${error}`)
-				})
-		})
+			const response = await fetch(viewPath);
+			const contet = await response.text();
+			return { selector: view.selector, content: contet }
+
+		})).then(responses => {
+			responses.forEach(response => {
+				if (response === undefined) return;
+				if (response.selector) {
+					renderContent(response.content, response.selector)
+				} else {
+					renderContent(response.content)
+				}
+			})
+		}
+		).catch((error) => {
+			const el = document.querySelector(
+				window.PineconeRouter.settings.viewSelector ?? '#app'
+			)
+			if (el) {
+				el.dispatchEvent(
+					new CustomEvent('fetch-error', { detail: error })
+				)
+			}
+			console.error(`Pinecone Router: Fetch Error: ${error}`)
+		}).finally(() => {
+			window.dispatchEvent(window.PineconeRouter.loadEnd)
+		});
 	},
 }
 


### PR DESCRIPTION
This change should ensure in order processing when loading every view into the DOM. Previously, there was a race condition where child views would finish loading before a parent view and DOM parsing would fail.

I made a local build and included it in my project where it seemed to resolve the issues I encountered. 

This PR does not include any changes necessary in order to draft a new release.